### PR TITLE
Adding linux_aarch64 and linux_ppc64le support

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -26,6 +26,30 @@ jobs:
         CONFIG: linux_python3.8
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_aarch64_python3.6:
+        CONFIG: linux_aarch64_python3.6
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-aarch64
+      linux_aarch64_python3.7:
+        CONFIG: linux_aarch64_python3.7
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-aarch64
+      linux_aarch64_python3.8:
+        CONFIG: linux_aarch64_python3.8
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-aarch64
+      linux_ppc64le_python3.6:
+        CONFIG: linux_ppc64le_python3.6
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
+      linux_ppc64le_python3.7:
+        CONFIG: linux_ppc64le_python3.7
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
+      linux_ppc64le_python3.8:
+        CONFIG: linux_ppc64le_python3.8
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -82,4 +82,4 @@ jobs:
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -112,4 +112,4 @@ jobs:
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-      condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/linux_aarch64_python3.6.yaml
+++ b/.ci_support/linux_aarch64_python3.6.yaml
@@ -1,0 +1,22 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-aarch64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/linux_aarch64_python3.7.yaml
+++ b/.ci_support/linux_aarch64_python3.7.yaml
@@ -1,0 +1,22 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-aarch64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/.ci_support/linux_aarch64_python3.8.yaml
+++ b/.ci_support/linux_aarch64_python3.8.yaml
@@ -1,0 +1,22 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-aarch64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.8'

--- a/.ci_support/linux_ppc64le_python3.6.yaml
+++ b/.ci_support/linux_ppc64le_python3.6.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-ppc64le
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/linux_ppc64le_python3.7.yaml
+++ b/.ci_support/linux_ppc64le_python3.7.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-ppc64le
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/.ci_support/linux_ppc64le_python3.8.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-ppc64le
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.8'

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -29,6 +29,48 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
+              <td>linux_aarch64_python3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1900&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/setproctitle-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1900&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/setproctitle-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1900&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/setproctitle-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.8" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1900&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/setproctitle-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1900&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/setproctitle-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1900&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/setproctitle-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.8" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_python2.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1900&branchName=master">
@@ -118,12 +160,6 @@ Current build status
       </details>
     </td>
   </tr>
-  <tr>
-    <td>Linux_ppc64le</td>
-    <td>
-      <img src="https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg" alt="ppc64le disabled">
-    </td>
-  </tr>
 </table>
 
 Current release info
@@ -169,7 +205,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,3 +5,9 @@ max_py_ver: '37'
 max_r_ver: '35'
 travis:
   secure: {BINSTAR_TOKEN: 1AR5sdujqgj/Jyy3upNAsKRcFFu9MQIHDo1SHTQuuapUgnW+604I5NY6bmId1m/phtNUVLLUYbBrUyh6VF+PZGvQt/Z1VV+VaR70xpZjCACCO8cGxyfTmD97xOpGeNIaPwVxXKmavD3HsQhq7cACD63THlwmvC4QjpxOdIEndaawJmExp++uMCOq1mMfnh39ZKAS4suc5tHj8L+km4j/Cnv215bTb/dQW+K/Dkbk8eVxaQHMcfcFiDohdu8BFKXnGyGh3Ci+D1jcG9a5B5d1Ww2x1cLG0u2xee/kqJHAuiFiho423rK01DOMlyosaSj4KraZz8Xg3bjqS5lCdtnVyqJu2YbWrgxIK4ZxavN2hIpL2IEqz9vbntiTofRk5pm6TLOiGl3qAqggXdXI23/UJANsy/p9z0r8GYr65VYeHumAq1696umrdsbMmDC7dESNHN6+cI5vM30C6Y7RUnOvsZNsaveZTxI9tuiA4Uit50xif3AEg+dI809zgsNWXWtnL/ccTOv6bDurK10goj3l6gUWuFTKToTQ0m9JYNEh7Tv3BW2qe93Cod+QHWEJysr9VucOn0YNLQJIrM2p9h8icFuKm9cPL2Jt9Q06akHFe9XD0WY83PhAv6Vdqs6wbaTJsd8q/B4LF9yQVzVyTBft8QLxkg6hYya+kHMuuFnHTX8=}
+provider:
+  win: azure
+  osx: azure
+  linux: azure
+  linux_aarch64: azure
+  linux_ppc64le: azure

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 6283b7a58477dd8478fbb9e76defb37968ee4ba47b05ec1c053cb39638bd7398
 
 build:
-  number: 1001
+  number: 1002
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
Setproctitle is a dependency for [RADICAL-Utils](https://github.com/radical-cybertools/radical.utils). Currently, RADICAL-Utils support `linux`, and `OS X`. We would like to extend our support to `linux-ppc64le` and `linux_aarch64`. This would require Setproctitle to be able to be installed in such architectures.

This PR makes the necessary changes to add that support.
 
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
